### PR TITLE
Add manual flipper use in cheat mode using , and . keys

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -62,6 +62,7 @@ export const actions = wireActions({
   reset: action<{ play?: boolean }>(),
   stepForward: action<{}>(),
   execute: action<{ op: OpCode }>(),
+  flipper: action<{ side: string; pressed: boolean }>(),
   commitSimulationState: action<{ state: SimulationState }>(),
   exitSimulation: action<{}>(),
 

--- a/src/components/ide.tsx
+++ b/src/components/ide.tsx
@@ -2,6 +2,7 @@ import React = require("react");
 import { connect, Dispatchers, actionCreatorsList } from "./connect";
 import { RootState, OpCode, CellSelection, OpCodeTypes } from "../types";
 import styled from "./styles";
+import { isCheating } from "../is-cheating";
 
 import { ContextMenu, MenuItem } from "react-contextmenu";
 
@@ -56,6 +57,7 @@ class IDE extends React.PureComponent<Props & DerivedProps> {
     return (
       <IDEDiv
         tabIndex={0}
+        onKeyUp={this.onKeyUp}
         onKeyDown={this.onKeyDown}
         innerRef={this.onDiv}
         onContextMenu={this.onContextMenu}
@@ -147,6 +149,27 @@ class IDE extends React.PureComponent<Props & DerivedProps> {
     }
   };
 
+  onKeyUp = (ev: React.KeyboardEvent<HTMLElement>) => {
+    let preventDefault = true;
+
+    if (ev.key == ",") {
+      if (isCheating()) {
+        this.props.flipper({ side: "left", pressed: false });
+      }
+    } else if (ev.key == ".") {
+      if (isCheating()) {
+        this.props.flipper({ side: "right", pressed: false });
+      }
+    } else {
+      preventDefault = false;
+      console.log(`key = ${ev.key}`);
+    }
+
+    if (preventDefault) {
+      ev.preventDefault();
+    }
+  };
+
   onKeyDown = (ev: React.KeyboardEvent<HTMLElement>) => {
     if (this.props.showHelp) {
       return;
@@ -204,6 +227,14 @@ class IDE extends React.PureComponent<Props & DerivedProps> {
       this.props.cellSetType({ type: "motor" });
     } else if (ev.key == "F") {
       this.props.cellSetType({ type: "freq" });
+    } else if (ev.key == ",") {
+      if (isCheating()) {
+        this.props.flipper({ side: "left", pressed: true });
+      }
+    } else if (ev.key == ".") {
+      if (isCheating()) {
+        this.props.flipper({ side: "right", pressed: true });
+      }
     } else {
       preventDefault = false;
       console.log(`key = ${ev.key}`);
@@ -233,6 +264,7 @@ const actionCreators = actionCreatorsList(
   "stepForward",
   "reset",
   "hideHelp",
+  "flipper",
 );
 
 type DerivedProps = {

--- a/src/components/pinball.tsx
+++ b/src/components/pinball.tsx
@@ -42,6 +42,14 @@ class Game extends React.PureComponent<Props & DerivedProps> {
       this.createWorld();
     });
 
+    w.on(actions.flipper, (state, action) => {
+      if (action.payload.side == "left") {
+        this.manualLeft = action.payload.pressed;
+      } else if (action.payload.side == "right") {
+        this.manualRight = action.payload.pressed;
+      }
+    });
+
     w.on(actions.execute, (store, action) => {
       const { op } = action.payload;
 
@@ -80,6 +88,8 @@ class Game extends React.PureComponent<Props & DerivedProps> {
 
   left = false;
   right = false;
+  manualLeft = false;
+  manualRight = false;
 
   step = () => {
     if (!this.running) {
@@ -92,10 +102,10 @@ class Game extends React.PureComponent<Props & DerivedProps> {
       this.map.ticks++;
 
       for (const j of this.map.rightJoints) {
-        physx.setRightEnabled(j, this.right);
+        physx.setRightEnabled(j, this.right || this.manualRight);
       }
       for (const j of this.map.leftJoints) {
-        physx.setLeftEnabled(j, this.left);
+        physx.setLeftEnabled(j, this.left || this.manualLeft);
       }
     }
 


### PR DESCRIPTION
- Cheat must be enabled
- Keyboard input comes from IDE component as well (I don't know how to make a global key handler w/ react)
- Only works when simulation is running
- Will override a "motor off", but cannot override a "motor on" - flipper state is "op || manual" basically
